### PR TITLE
Add native Android example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # TelsJinn
+
+This project provides examples for automating the Tesla "after blow" climate feature using the Tesla API.
+
+- The `mobile` directory contains a small React Native (Expo) app that works on iOS and Android.
+- The `android` directory offers a native Android implementation written in Kotlin.

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,15 @@
+# TelsJinn Android App
+
+This folder contains a minimal native Android implementation of the after blow feature.
+It uses Kotlin and OkHttp to communicate with the Tesla API.
+
+## Building
+
+1. Install Android Studio.
+2. Open this `android` folder as a project.
+3. Let Gradle download the dependencies.
+4. Connect an Android device or start an emulator.
+5. Run the **app** configuration from Android Studio.
+
+You will be prompted to enter a vehicle ID and your access token. You can also tap
+**Load Vehicles** to fetch your vehicles and populate the first vehicle ID.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    compileSdkVersion 33
+
+    defaultConfig {
+        applicationId "com.telsjinn"
+        minSdkVersion 24
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.telsjinn">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="TelsJinn"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/telsjinn/MainActivity.kt
+++ b/android/app/src/main/java/com/telsjinn/MainActivity.kt
@@ -1,0 +1,91 @@
+package com.telsjinn
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import okhttp3.*
+import org.json.JSONObject
+import java.io.IOException
+
+class MainActivity : AppCompatActivity() {
+    private lateinit var vehicleIdInput: EditText
+    private lateinit var tokenInput: EditText
+    private lateinit var statusText: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        vehicleIdInput = findViewById(R.id.vehicle_id_input)
+        tokenInput = findViewById(R.id.token_input)
+        statusText = findViewById(R.id.status_text)
+
+        findViewById<Button>(R.id.load_button).setOnClickListener {
+            loadVehicles(tokenInput.text.toString())
+        }
+
+        findViewById<Button>(R.id.after_blow_button).setOnClickListener {
+            sendAfterBlow(vehicleIdInput.text.toString(), tokenInput.text.toString())
+        }
+    }
+
+    private fun loadVehicles(token: String) {
+        statusText.text = "Loading vehicles..."
+        val request = Request.Builder()
+            .url("https://owner-api.teslamotors.com/api/1/vehicles")
+            .header("Authorization", "Bearer $token")
+            .build()
+
+        OkHttpClient().newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                runOnUiThread { statusText.text = "Error: ${'$'}{e.message}" }
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                response.use {
+                    val body = it.body?.string()
+                    if (body != null) {
+                        val data = JSONObject(body)
+                        val arr = data.getJSONArray("response")
+                        if (arr.length() > 0) {
+                            val vehicle = arr.getJSONObject(0)
+                            val vid = vehicle.getLong("id")
+                            runOnUiThread {
+                                vehicleIdInput.setText(vid.toString())
+                                statusText.text = "Loaded vehicle: ${'$'}{vehicle.getString("display_name")}"
+                            }
+                        } else {
+                            runOnUiThread { statusText.text = "No vehicles found" }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    private fun sendAfterBlow(vehicleId: String, token: String) {
+        statusText.text = "Sending command..."
+        val request = Request.Builder()
+            .url("https://owner-api.teslamotors.com/api/1/vehicles/${'$'}vehicleId/command/after_blow")
+            .post(RequestBody.create(null, ByteArray(0)))
+            .header("Authorization", "Bearer $token")
+            .build()
+
+        OkHttpClient().newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                runOnUiThread { statusText.text = "Error: ${'$'}{e.message}" }
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                if (response.isSuccessful) {
+                    runOnUiThread { statusText.text = "After blow triggered" }
+                } else {
+                    runOnUiThread { statusText.text = "Command failed" }
+                }
+            }
+        })
+    }
+}
+

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/vehicle_id_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Vehicle ID" />
+
+    <EditText
+        android:id="@+id/token_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Access Token"
+        android:inputType="textPassword" />
+
+    <Button
+        android:id="@+id/load_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Load Vehicles" />
+
+    <Button
+        android:id="@+id/after_blow_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Trigger After Blow" />
+
+    <TextView
+        android:id="@+id/status_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp" />
+</LinearLayout>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name = 'TelsJinn'

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { startAfterBlow, fetchVehicles } from './TeslaAPI';
+
+export default function App() {
+  const [vehicleId, setVehicleId] = useState('');
+  const [token, setToken] = useState('');
+  const [vehicles, setVehicles] = useState([]);
+  const [status, setStatus] = useState('');
+
+  const trigger = async () => {
+    setStatus('Sending command...');
+    try {
+      const res = await startAfterBlow(vehicleId, token);
+      if (res && res.response) {
+        setStatus('After blow triggered');
+      } else {
+        setStatus('Command failed');
+      }
+    } catch (e) {
+      setStatus('Error: ' + e.message);
+    }
+  };
+
+  const loadVehicles = async () => {
+    setStatus('Loading vehicles...');
+    try {
+      const data = await fetchVehicles(token);
+      if (data && data.response && data.response.length > 0) {
+        setVehicles(data.response);
+        setVehicleId(String(data.response[0].id));
+        setStatus('Loaded vehicle: ' + data.response[0].display_name);
+      } else {
+        setStatus('No vehicles found');
+      }
+    } catch (e) {
+      setStatus('Error: ' + e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Tesla After Blow</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Vehicle ID"
+        value={vehicleId}
+        onChangeText={setVehicleId}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Access Token"
+        value={token}
+        onChangeText={setToken}
+      />
+      <Button title="Load Vehicles" onPress={loadVehicles} />
+      <Button title="Trigger After Blow" onPress={trigger} />
+      {vehicleId ? (
+        <Text style={styles.vehicle}>Selected Vehicle ID: {vehicleId}</Text>
+      ) : null}
+      <Text style={styles.status}>{status}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  title: {
+    fontSize: 20,
+    marginBottom: 12
+  },
+  input: {
+    width: '80%',
+    borderWidth: 1,
+    padding: 8,
+    marginBottom: 12
+  },
+  status: {
+    marginTop: 12
+  },
+  vehicle: {
+    marginTop: 12
+  }
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,13 @@
+# TelsJinn Mobile App
+
+This folder contains a small React Native (Expo) application that demonstrates how to send the Tesla "after blow" command using the Tesla API.
+
+## Running
+
+1. Install Node.js and `expo-cli`.
+2. Run `npm install` inside this folder.
+3. Use `npm run android` or `npm run ios` to launch the application.
+
+You will need a Tesla API access token. The app can fetch your vehicles from the Tesla API and automatically fill in the first vehicle ID.
+
+If you prefer a native Android version, see the `../android` folder.

--- a/mobile/TeslaAPI.js
+++ b/mobile/TeslaAPI.js
@@ -1,0 +1,25 @@
+export async function startAfterBlow(vehicleId, token) {
+  const url = `https://owner-api.teslamotors.com/api/1/vehicles/${vehicleId}/command/after_blow`; // Example endpoint
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    }
+  });
+
+  return res.json();
+}
+
+// Fetch the authenticated user's vehicles
+export async function fetchVehicles(token) {
+  const res = await fetch('https://owner-api.teslamotors.com/api/1/vehicles', {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    }
+  });
+
+  return res.json();
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,9 @@
+{
+  "expo": {
+    "name": "TelsJinn",
+    "slug": "telsjinn",
+    "version": "0.1.0",
+    "sdkVersion": "48.0.0",
+    "platforms": ["ios", "android"]
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "telsjinn",
+  "version": "0.1.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "18.2.0",
+    "react-native": "0.71.8"
+  }
+}


### PR DESCRIPTION
## Summary
- document Android and React Native options
- add minimal Kotlin-based Android app using OkHttp
- link native version from mobile README

## Testing
- `npm --version`
- `node --version`
- `npm test --silent` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685026d1a7948328b48cd3f071e238e7